### PR TITLE
Codec g711u with Mono <=> Stereo conversion

### DIFF
--- a/src/main/scala/za/co/monadic/scopus/g711u/G711uCodec.scala
+++ b/src/main/scala/za/co/monadic/scopus/g711u/G711uCodec.scala
@@ -21,6 +21,8 @@ import za.co.monadic.scopus.{SampleFrequency, Sf16000, Sf24000, Sf32000, Sf48000
 trait G711uCodec {
   def getCodecName: String = "g711u"
 
+  def channels: Int
+
   /**
     * Calculates the downsample factor needed for the input sampling frequency
     * @param fs The sample frequecy of the current signal
@@ -35,5 +37,103 @@ trait G711uCodec {
       case Sf48000 => 6
       case _       => throw new RuntimeException("Unsupported sample rate conversion")
     }
+
+  /**
+    * When audio codec is configured to use two channels, mix them into one.
+    * Otherwise return the source array.
+    *
+    * @param audio Audio data arranged as a contiguous block interleaved array of floats
+    * @return An array containing one mixed audio channel
+    */
+  def toMono(audio: Array[Float]): Array[Float] = {
+    if (channels == 1) {
+      audio
+    } else {
+      val out = new Array[Float](audio.length / 2)
+      var i   = 0
+      var j   = 0
+      while (i < audio.length - 1) {
+        out(j) = (audio(i) + audio(i + 1)) / 2f
+        i += 2
+        j += 1
+      }
+      out
+    }
+  }
+
+  /**
+    * When audio codec is configured to use two channels, mix them into one.
+    * Otherwise return the source array.
+    *
+    * @param audio Audio data arranged as a contiguous block interleaved array of short integers
+    * @return An array containing one mixed audio channel
+    */
+  def toMono(audio: Array[Short]): Array[Short] = {
+    if (channels == 1) {
+      audio
+    } else {
+      val out = new Array[Short](audio.length / 2)
+      var i   = 0
+      var j   = 0
+      while (i < audio.length - 1) {
+        out(j) = ((audio(i) + audio(i + 1)) / 2).toShort
+        i += 2
+        j += 1
+      }
+      out
+    }
+  }
+
+  /**
+    * When audio codec is configured to use two channels
+    * it duplicates one, mono channel into a stream containing left and right channel.
+    * Otherwise return the source array.
+    *
+    * @param audio Audio data arranged as a contiguous block array of floats
+    * @return An array containing interleaved array of duplicate audio channel.
+    */
+  def toStereo(audio: Array[Short]): Array[Short] = {
+    if (channels == 1) {
+      audio
+    } else {
+      val out = new Array[Short](audio.length * 2)
+      var i   = 0
+      var j   = 0
+      while (i < audio.length) {
+        val elem = audio(i)
+        out(j) = elem
+        out(j + 1) = elem
+        i += 1
+        j += 2
+      }
+      out
+    }
+  }
+
+  /**
+    * When audio codec is configured to use two channels
+    * it duplicates one, mono channel into a stream containing left and right channel.
+    * Otherwise return the source array.
+    *
+    * @param audio Audio data arranged as a contiguous block array of short integers
+    * @return An array containing interleaved array of duplicate audio channel.
+    */
+  def toStereo(audio: Array[Float]): Array[Float] = {
+    if (channels == 1) {
+      audio
+    } else {
+      val out = new Array[Float](audio.length * 2)
+      var i   = 0
+      var j   = 0
+      while (i < audio.length) {
+        val elem = audio(i)
+        out(j) = elem
+        out(j + 1) = elem
+        i += 1
+        j += 2
+      }
+      out
+    }
+  }
 
 }

--- a/src/main/scala/za/co/monadic/scopus/g711u/G711uDecoder.scala
+++ b/src/main/scala/za/co/monadic/scopus/g711u/G711uDecoder.scala
@@ -52,8 +52,6 @@ private object G711uDecoder {
 
 case class G711uDecoderShort(fs: SampleFrequency, channels: Int) extends DecoderShort with G711uCodec {
 
-  require(channels == 1, s"The $getDetail supports only mono audio")
-
   import G711uDecoder.uToLin
   import ArrayConversion._
 
@@ -74,8 +72,8 @@ case class G711uDecoderShort(fs: SampleFrequency, channels: Int) extends Decoder
       i += 1
     }
     up match {
-      case Some(u) => Success(floatToShort(u.process(shortToFloat(out))))
-      case None    => Success(out)
+      case Some(u) => Success(toStereo(floatToShort(u.process(shortToFloat(out)))))
+      case None    => Success(toStereo(out))
     }
   }
 
@@ -113,8 +111,6 @@ case class G711uDecoderShort(fs: SampleFrequency, channels: Int) extends Decoder
 case class G711uDecoderFloat(fs: SampleFrequency, channels: Int) extends DecoderFloat with G711uCodec {
   import G711uDecoder.uToLinF
 
-  require(channels == 1, s"The $getDetail supports only mono audio")
-
   private val factor = toFactor(fs)
   private val up     = if (factor == 1) None else Some(Upsampler(factor))
 
@@ -132,8 +128,8 @@ case class G711uDecoderFloat(fs: SampleFrequency, channels: Int) extends Decoder
       i += 1
     }
     up match {
-      case Some(u) => Success(u.process(out))
-      case None    => Success(out)
+      case Some(u) => Success(toStereo(u.process(out)))
+      case None    => Success(toStereo(out))
     }
   }
 

--- a/src/main/scala/za/co/monadic/scopus/g711u/G711uEncoder.scala
+++ b/src/main/scala/za/co/monadic/scopus/g711u/G711uEncoder.scala
@@ -23,7 +23,6 @@ import scala.util.{Success, Try}
 
 case class G711uEncoder(sampleFreq: SampleFrequency, channels: Int) extends Encoder with G711uCodec {
 
-  require(channels == 1, s"The $getDetail supports only mono audio")
   import ArrayConversion._
 
   private val BIAS   = 0x84 /* Bias for linear code. */
@@ -68,7 +67,6 @@ case class G711uEncoder(sampleFreq: SampleFrequency, channels: Int) extends Enco
 
   private def toMu(xIn: Float): Byte = toMu((xIn * PCM_NORM).toShort)
 
-
   /**
     * Encode a block of raw audio in integer format using the configured encoder
     *
@@ -76,10 +74,11 @@ case class G711uEncoder(sampleFreq: SampleFrequency, channels: Int) extends Enco
     * @return An array containing the compressed audio or the exception in case of a failure
     */
   override def apply(audio: Array[Short]): Try[Array[Byte]] = {
-    val out = new Array[Byte](audio.length / factor)
+    val mono = toMono(audio)
+    val out  = new Array[Byte](mono.length / factor)
     val dAudio = down match {
-      case Some(d) => floatToShort(d.process(shortToFloat(audio)))
-      case None    => audio
+      case Some(d) => floatToShort(d.process(shortToFloat(mono)))
+      case None    => mono
     }
     var i = 0
     while (i < dAudio.length) {
@@ -96,10 +95,11 @@ case class G711uEncoder(sampleFreq: SampleFrequency, channels: Int) extends Enco
     * @return An array containing the compressed audio or the exception in case of a failure
     */
   override def apply(audio: Array[Float]): Try[Array[Byte]] = {
-    val out = new Array[Byte](audio.length / factor)
+    val mono = toMono(audio)
+    val out  = new Array[Byte](mono.length / factor)
     val dAudio = down match {
-      case Some(d) => d.process(audio)
-      case None    => audio
+      case Some(d) => d.process(mono)
+      case None    => mono
     }
     var i = 0
     while (i < dAudio.length) {

--- a/src/test/scala/za/co/monadic/scopus/ScopusTest.scala
+++ b/src/test/scala/za/co/monadic/scopus/ScopusTest.scala
@@ -81,7 +81,8 @@ class ScopusTest extends AnyFunSpec with Matchers with GivenWhenThen with Before
       0.90
     ),
     ("PCM", mono, PcmEncoder(Sf8000, 1), PcmDecoderShort(Sf8000, 1), PcmDecoderFloat(Sf8000, 1), 0.95),
-    ("g.711u", mono, G711uEncoder(Sf8000, 1), G711uDecoderShort(Sf8000, 1), G711uDecoderFloat(Sf8000, 1), 0.90)
+    ("g.711u", mono, G711uEncoder(Sf8000, 1), G711uDecoderShort(Sf8000, 1), G711uDecoderFloat(Sf8000, 1), 0.90),
+    ("g.711u mono to stereo", mono, G711uEncoder(Sf8000, 2), G711uDecoderShort(Sf8000, 2), G711uDecoderFloat(Sf8000, 2), 0.90)
   )
 
   for ((desc, audio, enc, dec, decFloat, corrMin) <- codecs) {
@@ -226,10 +227,6 @@ class ScopusTest extends AnyFunSpec with Matchers with GivenWhenThen with Before
   describe("The G711u codec") {
 
     it("fails if an invalid codec construction is requested") {
-      a[IllegalArgumentException] should be thrownBy G711uEncoder(Sf8000, 2)
-      a[IllegalArgumentException] should be thrownBy G711uDecoderFloat(Sf8000, 2)
-      a[IllegalArgumentException] should be thrownBy G711uDecoderShort(Sf8000, 2)
-
       a[RuntimeException] should be thrownBy G711uEncoder(Sf12000, 1)
       a[RuntimeException] should be thrownBy G711uDecoderShort(Sf12000, 1)
       a[RuntimeException] should be thrownBy G711uDecoderFloat(Sf12000, 1)


### PR DESCRIPTION
Ability of using g711u codec with stereo audio. When codec is configured to use two audio channels:
- `encoder` average the left and right (L+R)/2 channels to go back to mono 
- `decoder` is duplicating mono channel into left and right channel.